### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/nvblox_ros/CMakeLists.txt
+++ b/nvblox_ros/CMakeLists.txt
@@ -38,6 +38,7 @@ find_package(libstatistics_collector REQUIRED)
 find_package(message_filters REQUIRED)
 find_package(Threads REQUIRED)
 find_package(nvblox REQUIRED)
+find_package(glog REQUIRED)
 
 ########
 # CUDA #


### PR DESCRIPTION
Fix build issue with glog missing:
```
CMake Error at CMakeLists.txt:89 (add_executable):
  Target "3dmatch_node" links to target "glog::glog" but the target was not
  found.  Perhaps a find_package() call is missing for an IMPORTED target, or
  an ALIAS target is missing?
```