### PR TITLE
Enable multiple color image encodings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 **/build
+**/log
+**/install
 
 
 # Prerequisites

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = nvblox
 	url = https://github.com/nvidia-isaac/nvblox.git
 	branch = public
+[submodule "cuda_image_convert"]
+	path = cuda_image_convert
+	url = git@github.com:nakai-omer/cuda_image_convert.git

--- a/nvblox_ros/CMakeLists.txt
+++ b/nvblox_ros/CMakeLists.txt
@@ -39,6 +39,7 @@ find_package(message_filters REQUIRED)
 find_package(Threads REQUIRED)
 find_package(nvblox REQUIRED)
 find_package(glog REQUIRED)
+find_package(cuda_image_convert REQUIRED)
 
 ########
 # CUDA #
@@ -55,7 +56,7 @@ add_library(${PROJECT_NAME}_lib SHARED
   src/lib/transformer.cpp
   src/lib/nvblox_node.cpp
 )
-target_link_libraries(${PROJECT_NAME}_lib nvblox::nvblox_lib nvblox::nvblox_eigen)
+target_link_libraries(${PROJECT_NAME}_lib nvblox::nvblox_lib nvblox::nvblox_eigen cuda_image_convert)
 ament_target_dependencies(${PROJECT_NAME}_lib
   nvblox
   sensor_msgs
@@ -67,6 +68,7 @@ ament_target_dependencies(${PROJECT_NAME}_lib
   tf2_ros
   tf2_eigen
   message_filters
+  cuda_image_convert
 )
 target_include_directories(${PROJECT_NAME}_lib PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/nvblox_ros/CMakeLists.txt
+++ b/nvblox_ros/CMakeLists.txt
@@ -38,6 +38,7 @@ find_package(libstatistics_collector REQUIRED)
 find_package(message_filters REQUIRED)
 find_package(Threads REQUIRED)
 find_package(nvblox REQUIRED)
+find_package(glog REQUIRED)
 
 ########
 # CUDA #

--- a/nvblox_ros/include/nvblox_ros/conversions.hpp
+++ b/nvblox_ros/include/nvblox_ros/conversions.hpp
@@ -21,6 +21,8 @@
 #include <sensor_msgs/msg/camera_info.hpp>
 #include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
+#include <cudaColorspace.h>
+#include <cudaMappedMemory.h>
 
 namespace nvblox
 {

--- a/nvblox_ros/package.xml
+++ b/nvblox_ros/package.xml
@@ -17,12 +17,12 @@ license agreement from NVIDIA CORPORATION is strictly prohibited.
   <description>NVBlox ROS2 interface</description>
 
   <maintainer email="holeynikova@nvidia.com">Helen Oleynikova</maintainer>
-  <maintainer email="hemals@nvidia.com">Hemal Shah</maintainer> 
+  <maintainer email="hemals@nvidia.com">Hemal Shah</maintainer>
   <license>NVIDIA Isaac ROS Software License</license>
-  <url type="website">https://developer.nvidia.com/isaac-ros-gems/</url>   
+  <url type="website">https://developer.nvidia.com/isaac-ros-gems/</url>
   <author>Helen Oleynikova</author>
   <author>Alexander Millane</author>
-  
+
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 

--- a/nvblox_ros/src/lib/conversions.cpp
+++ b/nvblox_ros/src/lib/conversions.cpp
@@ -37,14 +37,35 @@ bool RosConverter::colorImageFromImageMessage(
 {
   CHECK_NOTNULL(color_image);
 
-  // First check if we actually have a valid image here.
+  void* final_image = NULL;
+
   if (image_msg->encoding != "rgb8") {
-    return false;
+    if(!cudaAllocMapped(&final_image, image_msg->width, image_msg->height, IMAGE_RGB8)) {
+      return false;
+    }
+
+    auto input_format = imageFormatFromStr(image_msg->encoding.c_str());
+    void* inputCPU = NULL;
+    void* inputGPU = NULL;
+    auto input_size = imageFormatSize(input_format, image_msg->width, image_msg->height);
+
+    if (!cudaAllocMapped((void**)&inputCPU, (void**)&inputGPU, input_size)) {
+      return false;
+    }
+
+    memcpy(inputCPU, image_msg->data.data(), input_size);
+  
+    if(CUDA_FAILED(cudaConvertColor(inputGPU, input_format, final_image, IMAGE_RGB8, image_msg->width, image_msg->height)))	{
+			return false;
+		}
+  } 
+  else {
+    final_image = const_cast<uint8_t*>(&image_msg->data[0]);
   }
 
   color_image->populateFromBuffer(
     image_msg->height, image_msg->width,
-    reinterpret_cast<const Color *>(&image_msg->data[0]), MemoryType::kDevice);
+    reinterpret_cast<const Color *>(final_image), MemoryType::kDevice);
 
   return true;
 }


### PR DESCRIPTION
Currently the only supported encoding is RGB8. We have extracted the image conversion utilities from jetson-utils (which is only supported on jetson so we couldn't use directly), and used it for GPU optimized conversions. Now many more image formats are supported, and the added lib can help in other areas as well. 
This is also needed specifically for usage with the ZED camera as it outputs BGRA8 encoding. 