### PR TITLE
add smac planner support

### DIFF
--- a/nvblox_nav2/include/nvblox_nav2/nvblox_costmap_layer.hpp
+++ b/nvblox_nav2/include/nvblox_nav2/nvblox_costmap_layer.hpp
@@ -21,9 +21,11 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 #include <tf2_ros/transform_listener.h>
+#include <mutex>
 #include <string>
 #include <memory>
 #include <nav2_costmap_2d/costmap_layer.hpp>
+#include <nav2_costmap_2d/inflation_layer_interface.hpp>
 #include <nav2_costmap_2d/layer.hpp>
 #include <nav2_costmap_2d/layered_costmap.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -35,7 +37,8 @@ namespace nvblox
 namespace nav2
 {
 
-class NvbloxCostmapLayer : public nav2_costmap_2d::CostmapLayer
+class NvbloxCostmapLayer : public nav2_costmap_2d::CostmapLayer,
+  public nav2_costmap_2d::InflationLayerInterface
 {
 public:
   NvbloxCostmapLayer();
@@ -51,6 +54,12 @@ public:
 
   void reset() override {}
   bool isClearable() override {return true;}
+
+  // InflationLayerInterface
+  double getCostScalingFactor() override;
+  double getInflationRadius() override;
+  mutex_t * getMutex() override;
+  unsigned char computeCost(double distance) const override;
 
   void sliceCallback(
     const nvblox_msgs::msg::DistanceMapSlice::ConstSharedPtr slice);
@@ -80,6 +89,9 @@ private:
   std::unique_ptr<tf2_ros::Buffer> tf_buffer_;
   std::shared_ptr<tf2_ros::TransformListener> transform_listener_;
   Eigen::Isometry2f T_G_S_;
+
+  // Mutex for InflationLayerInterface
+  mutex_t access_mutex_;
 };
 
 }  // namespace nav2

--- a/nvblox_nav2/package.xml
+++ b/nvblox_nav2/package.xml
@@ -21,7 +21,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>nvblox_nav2</name>
-  <version>4.3.0</version>
+  <version>4.3.1</version>
   <description>NVBlox ROS 2 Nav2 interface</description>
 
   <maintainer email="isaac-ros-maintainers@nvidia.com">Isaac ROS Maintainers</maintainer>

--- a/nvblox_nav2/src/nvblox_costmap_layer.cpp
+++ b/nvblox_nav2/src/nvblox_costmap_layer.cpp
@@ -327,6 +327,46 @@ bool NvbloxCostmapLayer::lookupInSlice(const Eigen::Vector2f & pos, float * dist
   return false;
 }
 
+double NvbloxCostmapLayer::getCostScalingFactor()
+{
+  // Derived from the exponential decay: cost = max_cost * exp(-factor * (distance - inscribed))
+  // We approximate factor so that cost decays to ~1 at max_obstacle_distance_.
+  if (max_obstacle_distance_ > inflation_distance_) {
+    return static_cast<double>(
+      std::log(max_cost_value_) / (max_obstacle_distance_ - inflation_distance_));
+  }
+  return 10.0;
+}
+
+double NvbloxCostmapLayer::getInflationRadius()
+{
+  return static_cast<double>(max_obstacle_distance_);
+}
+
+NvbloxCostmapLayer::mutex_t * NvbloxCostmapLayer::getMutex()
+{
+  return &access_mutex_;
+}
+
+unsigned char NvbloxCostmapLayer::computeCost(double distance) const
+{
+  if (distance <= 0.0) {
+    return nav2_costmap_2d::LETHAL_OBSTACLE;
+  }
+  if (distance < inflation_distance_) {
+    return nav2_costmap_2d::INSCRIBED_INFLATED_OBSTACLE;
+  }
+  if (distance > max_obstacle_distance_) {
+    return nav2_costmap_2d::FREE_SPACE;
+  }
+  return static_cast<unsigned char>(
+    max_cost_value_ *
+    (1.0 - std::min(
+      (distance - inflation_distance_) /
+      static_cast<double>(max_obstacle_distance_),
+      1.0)));
+}
+
 }  // namespace nav2
 }  // namespace nvblox
 


### PR DESCRIPTION
Just as a heads up as you calculate inflation values within the costmap layer, I think it would be beneficial to inherit from InflationLayerInterface, so that the smac planner can actually work based on the already calculated inflation.
As reference, this is what the smac planner requires to apply the collision check optimizations.
https://github.com/ros-navigation/navigation2/blob/691af6e3bd1dfc4edf5ac805f165510697bcc26e/nav2_smac_planner/include/nav2_smac_planner/utils.hpp#L75
